### PR TITLE
Changed "rm -r" to "rm -rf"

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ cd yay
 makepkg -si
 
 cd ~
-rm -r /tmp/yay_install
+rm -rf /tmp/yay_install
 ```
 
 #### Install Pywal


### PR DESCRIPTION
Hey, in the install yay section, i encountered an issue wherein the terminal was recursively asking me whether i wanted to delete write-only files. I checked the forums and the fix was to change rm -r to rm -rf. Please do not merge if its wrong. :-)  